### PR TITLE
Add CI workflow for IntroductionToComposeForTV codelab

### DIFF
--- a/.github/workflows/IntroductionToComposeForTV-build-app.yml
+++ b/.github/workflows/IntroductionToComposeForTV-build-app.yml
@@ -1,0 +1,33 @@
+# Workflow name
+name: Build IntroductionToComposeForTV Codelab
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set Up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+          cache: 'gradle'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+        working-directory: ./tv-codelabs/IntroductionToComposeForTV
+
+      - name: Build app
+        working-directory: ./tv-codelabs/IntroductionToComposeForTV
+        run: ./gradlew :app:assembleDebug


### PR DESCRIPTION
This commit adds a new GitHub Actions workflow for building the IntroductionToComposeForTV codelab. The workflow is triggered on push and pull requests to the main branch, and it can be triggered manually with `workflow_dispatch`, and it performs the following steps:

- Checks out the code
- Sets up JDK 17
- Sets up Gradle
- Makes the gradlew executable
- Builds the app