### PR TITLE
Fix working directory in CI workflow

### DIFF
--- a/.github/workflows/IntroductionToComposeForTV-build-app.yml
+++ b/.github/workflows/IntroductionToComposeForTV-build-app.yml
@@ -26,8 +26,8 @@ jobs:
 
       - name: Make gradlew executable
         run: chmod +x ./gradlew
-        working-directory: ./tv-codelabs/IntroductionToComposeForTV
+        working-directory: ./IntroductionToComposeForTV
 
       - name: Build app
-        working-directory: ./tv-codelabs/IntroductionToComposeForTV
+        working-directory: ./IntroductionToComposeForTV
         run: ./gradlew :app:assembleDebug


### PR DESCRIPTION
The previous CI workflow had an incorrect working directory. This commit corrects the directory to
ensure the workflow runs in the correct location.

- Corrected working directory to `./IntroductionToComposeForTV`